### PR TITLE
fix: do not path SOURCE_KEY to gitops release

### DIFF
--- a/.github/workflows/release-test.yaml
+++ b/.github/workflows/release-test.yaml
@@ -71,8 +71,7 @@ jobs:
 
   release_gitops:
     if: ${{ github.event.inputs.release_gitops == 'true' }}
-    uses: ActionTestingX/action-toolbox/.github/workflows/tool-release-gitops.yaml@ka1
+    uses: ActionTestingX/action-toolbox/.github/workflows/tool-release-gitops-update.yaml@ka1
     secrets:
       CONTAINER_REGISTRY_ACR_URL: ${{ secrets.CONTAINER_REGISTRY_ACR_URL }}
-      SOURCE_KEY: ${{ secrets.SOURCE_KEY }}
       GITOPS_KEY: ${{ secrets.GITOPS_KEY }}


### PR DESCRIPTION
# Overview

Describe the purpose of this PR here.

<!--
Please keep your PR description short and to the point. 
The PR should also be focused on a single issue, so please don't mix multiple fixes in one PR.
-->